### PR TITLE
Add .gitignore and .gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+
+dist/*
+!dist/.gitkeep
+
+output


### PR DESCRIPTION
Previously, the user would have to create their own dist directory if they wanted to successfully make the project. Now, the dist directory is already in the project (without any of its contents).

This also allows for more convenient pulling if you want to make a change without having to delete all the residue from a compilation.